### PR TITLE
Explicit db selection via Connection instance fixed

### DIFF
--- a/credis/base.pyx
+++ b/credis/base.pyx
@@ -164,13 +164,13 @@ cdef class Connection(object):
         # if a password is specified, authenticate
         if self.password is not None:
             self.send_command(('AUTH', self.password))
-            if <basestring>self.read_response() != 'OK':
+            if self.read_response().decode() != 'OK':
                 raise AuthenticationError('Invalid Password')
 
         # if a database is specified, switch to it
         if self.db is not None:
             self.send_command(('SELECT', self.db))
-            if <basestring>self.read_response() != 'OK':
+            if self.read_response().decode() != 'OK':
                 raise ConnectionError('Invalid Database')
 
     cpdef disconnect(self):

--- a/test/pool.py
+++ b/test/pool.py
@@ -47,7 +47,7 @@ def random_worker():
     return random.choice([worker_normal, worker_exception, worker_using_with, worker_using_with2])
 
 pool = ResourcePool(10, get_resource)
-threads = [gevent.spawn(random_worker(), pool) for i in xrange(1000)]
+threads = [gevent.spawn(random_worker(), pool) for i in range(1000)]
 gevent.joinall(threads)
 assert pool.alloc_count <= pool.max_count
 assert pool.used_count == 0

--- a/test/simple.py
+++ b/test/simple.py
@@ -3,18 +3,40 @@ from credis import Connection
 
 conn = Connection()
 
-assert conn.execute('SET', 1, 1) == 'OK'
-assert conn.execute('GET', 1) == '1'
+assert conn.execute('SET', 1, 1) == b'OK'
+assert conn.execute('GET', 1) == b'1'
 
 # pipeline
 assert conn.execute_pipeline(
         ('SET', 1, 2),
         ('GET', 1),
-    ) == ('OK', '2')
+    ) == (b'OK', b'2')
 
 assert conn.execute_pipeline(
         ('SET', 1, 1),
         ('INCR', 1),
         ('INCRBY', 1, 1),
         ('GET', 1),
-    ) == ('OK', 2, 3, '3')
+    ) == (b'OK', 2, 3, b'3')
+
+
+# Connection with explicit db selection.
+conn_with_explicit_db = Connection(db=7)
+
+assert conn_with_explicit_db.execute('SET', 1, 1) == b'OK'
+assert conn_with_explicit_db.execute('GET', 1) == b'1'
+
+# pipeline
+assert conn_with_explicit_db.execute_pipeline(
+        ('SET', 1, 2),
+        ('GET', 1),
+    ) == (b'OK', b'2')
+
+assert conn_with_explicit_db.execute_pipeline(
+        ('SET', 1, 1),
+        ('INCR', 1),
+        ('INCRBY', 1, 1),
+        ('GET', 1),
+    ) == (b'OK', 2, 3, b'3')
+
+


### PR DESCRIPTION
When it is tried to get a connection instance with an explicit db selection, following error showed up:

```python
from credis import Connection

conn = Connection(db=4)

assert conn.execute('SET', 1, 1) == 'OK'
assert conn.execute('GET', 1) == '1'

# pipeline
assert conn.execute_pipeline(
        ('SET', 1, 2),
        ('GET', 1),
    ) == ('OK', '2')

assert conn.execute_pipeline(
        ('SET', 1, 1),
        ('INCR', 1),
        ('INCRBY', 1, 1),
        ('GET', 1),
    ) == ('OK', 2, 3, '3')

```

```
Traceback (most recent call last):
  File "/Users/anil/PersonalProjects/credisfork/credis/test/simple.py", line 6, in <module>
    assert conn.execute('SET', 1, 1) == 'OK'
  File "credis/base.pyx", line 339, in credis.base.Connection.execute
  File "credis/base.pyx", line 205, in credis.base.Connection.send_command
  File "credis/base.pyx", line 190, in credis.base.Connection.send_packed_command
  File "credis/base.pyx", line 140, in credis.base.Connection.connect
  File "credis/base.pyx", line 174, in credis.base.Connection._init_connection
credis.base.ConnectionError: Invalid Database
```

It seemed that basestring casting in the `base.pyx` does not work as expected. 
So, it is modified in a way that it will be able to meet to expectations:

```cython
cdef _init_connection(self):
    "Initialize the connection, authenticate and select a database"

    # if a password is specified, authenticate
    if self.password is not None:
        self.send_command(('AUTH', self.password))
        # if <basestring>self.read_response() != 'OK':
        if self.read_response().decode() != 'OK':
            raise AuthenticationError('Invalid Password')

    # if a database is specified, switch to it
    if self.db is not None:
        self.send_command(('SELECT', self.db))
        # if <basestring>self.read_response() != 'OK':
        if self.read_response().decode() != 'OK':
            raise ConnectionError('Invalid Database')

```

After applying the changes mentioned above and running `simple.py`, following showed up:

```
Traceback (most recent call last):
  File "/Users/anil/PersonalProjects/credisfork/credis/test/simple.py", line 6, in <module>
    assert conn.execute('SET', 1, 1) == 'OK'
AssertionError

```

This one seemed that just like the previous one, the response is `b'OK'` instead of `'OK'`.
So, following will fix it.

```python
from credis import Connection

conn = Connection(db=4)

assert conn.execute('SET', 1, 1) == b'OK'
assert conn.execute('GET', 1) == b'1'

# pipeline
assert conn.execute_pipeline(
        ('SET', 1, 2),
        ('GET', 1),
    ) == (b'OK', b'2')

assert conn.execute_pipeline(
        ('SET', 1, 1),
        ('INCR', 1),
        ('INCRBY', 1, 1),
        ('GET', 1),
    ) == (b'OK', 2, 3, b'3')
```

Finally, this scenario added to the test scenarios as well.
```python
#!/usr/bin/env python
from credis import Connection

conn = Connection()

assert conn.execute('SET', 1, 1) == b'OK'
assert conn.execute('GET', 1) == b'1'

# pipeline
assert conn.execute_pipeline(
        ('SET', 1, 2),
        ('GET', 1),
    ) == (b'OK', b'2')

assert conn.execute_pipeline(
        ('SET', 1, 1),
        ('INCR', 1),
        ('INCRBY', 1, 1),
        ('GET', 1),
    ) == (b'OK', 2, 3, b'3')


# Connection with explicit db selection.
conn_with_explicit_db = Connection(db=7)

assert conn_with_explicit_db.execute('SET', 1, 1) == b'OK'
assert conn_with_explicit_db.execute('GET', 1) == b'1'

# pipeline
assert conn_with_explicit_db.execute_pipeline(
        ('SET', 1, 2),
        ('GET', 1),
    ) == (b'OK', b'2')

assert conn_with_explicit_db.execute_pipeline(
        ('SET', 1, 1),
        ('INCR', 1),
        ('INCRBY', 1, 1),
        ('GET', 1),
    ) == (b'OK', 2, 3, b'3')

```